### PR TITLE
Catch all exceptions and raise a WebScraperError instead

### DIFF
--- a/suseapi/browser.py
+++ b/suseapi/browser.py
@@ -74,6 +74,10 @@ def webscraper_safely(call, *args, **kwargs):
     # There doesn't seem to be an oserror that is already caught here?
     except IOError as exc:  # pylint: disable=duplicate-except
         raise WebScraperError('IO error: {0!s}'.format(exc), exc)
+    except WebScraperError:
+        raise
+    except Exception as exc:
+        raise WebScraperError(*exc.args)
 
 
 class WebScraper(object):


### PR DESCRIPTION
My suggestion for a patch for #8.

By ensuring that the function only raises `WebScraperError`s developers using this function in other projects do not have to worry, what's happening there.